### PR TITLE
Eliminate a reference cycle caused by the Spitfire placeholder_cache.

### DIFF
--- a/spitfire/runtime/udn.py
+++ b/spitfire/runtime/udn.py
@@ -137,9 +137,9 @@ def _resolve_placeholder(name, template, global_vars):
     if placeholder_cache and name in placeholder_cache:
         ph = placeholder_cache[name]
         if isinstance(ph, weakref.ReferenceType) and ph() is not None:
-          return ph()
+            return ph()
         elif not isinstance(ph, weakref.ReferenceType):
-          return ph
+            return ph
 
     # Note: getattr with 3 args is somewhat slower if the attribute
     # is found, but much faster if the attribute is not found.

--- a/spitfire/runtime/udn.py
+++ b/spitfire/runtime/udn.py
@@ -138,8 +138,8 @@ def _resolve_placeholder(name, template, global_vars):
         ph = placeholder_cache[name]
         if isinstance(ph, weakref.ReferenceType):
             v = ph()
-            if ph is not None:
-                return ph
+            if v is not None:
+                return v
         else:
             return ph
 

--- a/spitfire/runtime/udn.py
+++ b/spitfire/runtime/udn.py
@@ -136,9 +136,11 @@ def _resolve_placeholder(name, template, global_vars):
     placeholder_cache = template.placeholder_cache
     if placeholder_cache and name in placeholder_cache:
         ph = placeholder_cache[name]
-        if isinstance(ph, weakref.ReferenceType) and ph() is not None:
-            return ph()
-        elif not isinstance(ph, weakref.ReferenceType):
+        if isinstance(ph, weakref.ReferenceType):
+            v = ph()
+            if ph is not None:
+                return ph
+        else:
             return ph
 
     # Note: getattr with 3 args is somewhat slower if the attribute

--- a/spitfire/runtime/udn.py
+++ b/spitfire/runtime/udn.py
@@ -147,6 +147,7 @@ def _resolve_placeholder(name, template, global_vars):
     result = getattr(template, name, udn_ph)
     if result is not udn_ph:
         if placeholder_cache is not None:
+            # Use a weakref for methods to prevent memory cycles.
             placeholder_cache[name] = weakref.ref(result) if inspect.ismethod(
                 result) else result
         return result
@@ -156,6 +157,7 @@ def _resolve_placeholder(name, template, global_vars):
         ph = resolve_from_search_list(search_list, name)
         if ph is not UnresolvedPlaceholder:
             if placeholder_cache is not None:
+                # Use a weakref for methods to prevent memory cycles.
                 placeholder_cache[name] = weakref.ref(ph) if inspect.ismethod(
                     ph) else ph
             return ph

--- a/spitfire/runtime/udn_test.py
+++ b/spitfire/runtime/udn_test.py
@@ -22,6 +22,9 @@ class Foo(object):
     search_list = [{'win': 'boo'}, Scope(),]
     placeholder_cache = None
 
+    def foo_method(self):
+      pass
+
 
 class TestResolvePlaceholder(unittest.TestCase):
 
@@ -62,6 +65,13 @@ class TestResolvePlaceholderWithCache(unittest.TestCase):
         self.assertEqual(udn.resolve_placeholder('boom', template, None), 'bam')
         self.assertIn('boom', template.placeholder_cache)
         self.assertEqual(udn.resolve_placeholder('boom', template, None), 'bam')
+
+    def test_method_cycle_elimination(self):
+        template = Foo()
+        template.placeholder_cache = {}
+        self.assertEqual(udn.resolve_placeholder('foo_method', template, None), template.foo_method)
+        self.assertIn('foo_method', template.placeholder_cache)
+        self.assertEqual(udn.resolve_placeholder('foo_method', template, None), template.foo_method)
 
 
 class TestResolvePlaceholderWithLocals(unittest.TestCase):

--- a/spitfire/runtime/udn_test.py
+++ b/spitfire/runtime/udn_test.py
@@ -4,6 +4,7 @@
 # license that can be found in the LICENSE file.
 
 import unittest
+import weakref
 
 from spitfire import runtime
 from spitfire.runtime import udn
@@ -71,6 +72,7 @@ class TestResolvePlaceholderWithCache(unittest.TestCase):
         template.placeholder_cache = {}
         self.assertEqual(udn.resolve_placeholder('foo_method', template, None), template.foo_method)
         self.assertIn('foo_method', template.placeholder_cache)
+        self.assertIsInstance(template.placeholder_cache['foo_method'], weakref.ReferenceType)
         self.assertEqual(udn.resolve_placeholder('foo_method', template, None), template.foo_method)
 
 


### PR DESCRIPTION
Uses weakref.proxy() when adding methods to the cache in order to avoid reference cycles.