### PR TITLE
Removing pypy from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "pypy"
 
 install:
   - make


### PR DESCRIPTION
The pypy build appears to be broken even on master (tested locally). I'm thinking we should have Travis test against 3.7 instead and forget PyPy support?