### PR TITLE
Migrate some essential runtime files to Python 3

### DIFF
--- a/spitfire/runtime/__init__.py
+++ b/spitfire/runtime/__init__.py
@@ -3,6 +3,10 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from third_party import six
 
 class __UnresolvedPlaceholder(object):
     pass
@@ -34,7 +38,7 @@ class UndefinedPlaceholder(object):
         self.__name = name
         self.__search_list = search_list
 
-    def __nonzero__(self):
+    def __bool__(self):
         return False
 
     def __str__(self):
@@ -54,7 +58,7 @@ class UndefinedAttribute(UndefinedPlaceholder):
 
 def _get_available_placeholders(scope):
     if isinstance(scope, dict):
-        return scope.keys()
+        return list(scope.keys())
     else:
         return [a
                 for a in dir(scope)
@@ -68,7 +72,7 @@ def import_module_symbol(name):
     module = __import__(module_name, globals(), locals(), [symbol_name])
     try:
         symbol = getattr(module, symbol_name)
-    except AttributeError, e:
+    except AttributeError as e:
         raise ImportError("can't import %s" % name)
     return symbol
 
@@ -76,7 +80,7 @@ def import_module_symbol(name):
 # map template function names to python function names
 # inject them into a module so they run as globals
 def register_functions(module, template_function_map):
-    for t_name, f_name in template_function_map.iteritems():
+    for t_name, f_name in six.iteritems(template_function_map):
         f_func = import_module_symbol(f_name)
         setattr(module, t_name, f_func)
 

--- a/spitfire/runtime/filters.py
+++ b/spitfire/runtime/filters.py
@@ -7,8 +7,10 @@
 
 import functools
 import types
+
 from spitfire import runtime
 from spitfire.runtime import udn
+from third_party import six
 
 
 # decorate a function object so the default filter will not be applied to the
@@ -37,7 +39,7 @@ def passthrough_filter(value):
 def escape_html(value, quote=True):
     """Replace special characters '&', '<' and '>' by SGML entities."""
     value = simple_str_filter(value)
-    if isinstance(value, basestring):
+    if isinstance(value, six.string_types):
         value = value.replace("&", "&amp;")  # Must be done first!
         value = value.replace("<", "&lt;")
         value = value.replace(">", "&gt;")
@@ -49,8 +51,8 @@ def escape_html(value, quote=True):
 # deprecated
 def safe_values(value):
     """Deprecated - use simple_str_filter instead."""
-    if isinstance(value, (str, unicode, int, long, float,
-                          runtime.UndefinedPlaceholder)):
+    if isinstance(value, (str, six.text_type, float,
+                          runtime.UndefinedPlaceholder) + six.integer_types):
         return value
     else:
         return ''
@@ -58,8 +60,8 @@ def safe_values(value):
 
 def simple_str_filter(value):
     """Return a string if the input type is something primitive."""
-    if isinstance(value, (str, unicode, int, long, float,
-                          runtime.UndefinedPlaceholder)):
+    if isinstance(value, (str, unicode, float,
+                          runtime.UndefinedPlaceholder) + six.integer_types):
         # fixme: why do force this conversion here?
         # do we want to be unicode or str?
         return str(value)

--- a/spitfire/runtime/udn.py
+++ b/spitfire/runtime/udn.py
@@ -9,11 +9,11 @@
 # syntactically, 'name' will always be a valid identifier - so you won't get
 # name='my attribute' - it must be a legal python identifier
 
-import __builtin__
 import inspect
 import logging
 import weakref
 
+from third_party.six.moves import builtins
 from spitfire import runtime
 # Import the accelerated C module if available.
 try:
@@ -180,7 +180,7 @@ def _resolve_placeholder(name, template, global_vars):
     # fixme: finally try to resolve builtins - this should be configurable
     # if you compile optimized modes, this isn't necessary
     try:
-        return getattr(__builtin__, name)
+        return getattr(builtins, name)
     except AttributeError:
         return UndefinedPlaceholder(name, search_list)
 


### PR DESCRIPTION
We need to use portions of the runtime as part of the migration. Splitting out into a separate changelist should help expedite the work.